### PR TITLE
Default sorting to non-submitters at the top

### DIFF
--- a/src/web/app/components/sessions-table/send-reminders-to-respondents-modal/send-reminders-to-respondents-modal.component.ts
+++ b/src/web/app/components/sessions-table/send-reminders-to-respondents-modal/send-reminders-to-respondents-modal.component.ts
@@ -28,7 +28,6 @@ export class SendRemindersToRespondentsModalComponent {
   }
 
   ngOnInit() {
-    console.log(this.studentListInfoTableRowModels);
     this.studentListInfoTableRowModels.sort((a, b) => {
       if (a.hasSubmittedSession && !b.hasSubmittedSession) {
         return 1;

--- a/src/web/app/components/sessions-table/send-reminders-to-respondents-modal/send-reminders-to-respondents-modal.component.ts
+++ b/src/web/app/components/sessions-table/send-reminders-to-respondents-modal/send-reminders-to-respondents-modal.component.ts
@@ -27,6 +27,23 @@ export class SendRemindersToRespondentsModalComponent {
   constructor(public activeModal: NgbActiveModal) {
   }
 
+  ngOnInit() {
+    console.log(this.studentListInfoTableRowModels);
+    this.studentListInfoTableRowModels.sort((a, b) => {
+      if (a.hasSubmittedSession && !b.hasSubmittedSession) {
+        return 1;
+      } else if (!a.hasSubmittedSession && b.hasSubmittedSession) {
+        return -1;
+      } else {
+        if (a.name < b.name) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+    });
+  }
+
   /**
    * Changes selection state for all students.
    */


### PR DESCRIPTION
Experimental tweak to get familiar with teammates and how it is being structured.

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:
- [ ] Read and understood our PR guideline: https://teammates.github.io/teammates/process.html#step-4-submit-a-pr
  - [ ] Added the issue number to the "Fixes" keyword above
  - [ ] Titled the PR as specified in the abovementioned document
- [ ] Made your changes on a branch other than `master` and `release`
- [ ] Gone through all the changes in this PR and ensured that:
  - [ ] They addressed one (and only one) issue
  - [ ] No unintended changes were made
- [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [ ] Added/updated tests, if changes in functionality were involved
- [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Problem**
When selecting non-submitters to remind on the instructor's Feedback Session page, the lists are sorted according to name.  However, since the purpose of the selection is to focus on non-submitters, it makes sense to sort the list according to submission status first and then name.

**Outline of Solution**
A crude sorting mechanism is implemented in the `ngOnInit` method. I believe it's possible to use methods from the `respondent-list-info-table-component.ts` file, but I haven't quite figured out how to call those yet. As an experimental change, this has only been implemented for student lists. Upon selecting the option, the instructor should see something like this:
<img width="1127" alt="result" src="https://user-images.githubusercontent.com/48304907/208217089-582be6ca-6184-48ea-a7a7-377ee0f20b49.png">


<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
